### PR TITLE
TeX Live 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These files are released to the public domain. See the [Gregorio project](https:
 
 ####Changed
 - Both PKGBUILDs updated for compatibility with TeX Live 2016.
+- Build docs for `gregorio-git`.
 
 ###2016-05-30
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ These files are released to the public domain. See the [Gregorio project](https:
 
 ##Changelog
 
+###2016-08-09
+
+####Changed
+- Both PKGBUILDs updated for compatibility with TeX Live 2016.
+
 ###2016-05-30
 
 ####Changed

--- a/gregorio-git/PKGBUILD
+++ b/gregorio-git/PKGBUILD
@@ -27,7 +27,7 @@ prepare() {
   msg "Configuring..."
   cd "$srcdir/$pkgbase/"
   autoreconf -f -i
-  ./configure --prefix=/usr || return 1
+  ./configure --prefix=/usr/local || return 1
 }
 
 build() {
@@ -45,5 +45,5 @@ package() {
   make -j DESTDIR="$pkgdir/" install || return 1
   msg "Installing fonts and TeX files..."
   cd "$srcdir/$pkgbase/"
-  ./install-gtex.sh dir:$pkgdir/usr/share/texmf-dist || return 1
+  ./install-gtex.sh dir:$pkgdir/usr/share/texmf || return 1
 }

--- a/gregorio-git/PKGBUILD
+++ b/gregorio-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Br. Elijah Schwab (github - eschwab)
 pkgbase=gregorio-git
 pkgname=$pkgbase
-pkgver=4.1.0.r3487.fd7949f
+pkgver=4.2.0_rc2.r3900.f9b4ad0
 pkgrel=1
 pkgdesc="Command-line tool to typeset Gregorian chant"
 url=http://gregorio-project.github.io
@@ -37,6 +37,9 @@ build() {
   msg "Building fonts..."
   cd "$srcdir/$pkgbase/fonts/"
   make -j fonts || return 1
+  msg "Building docs..."
+  cd "$srcdir/$pkgbase/doc"
+  make -j pdf || return 1
 }
 
 package() {

--- a/gregorio/PKGBUILD
+++ b/gregorio/PKGBUILD
@@ -23,7 +23,7 @@ prepare() {
   msg "Configuring..."
   cd "$srcdir/$pkgbase/"
   autoreconf -f -i
-  ./configure --prefix=/usr || return 1
+  ./configure --prefix=/usr/local || return 1
 }
 
 build() {
@@ -38,5 +38,5 @@ package() {
   make -j DESTDIR="$pkgdir/" install || return 1
   msg "Installing fonts and TeX files..."
   cd "$srcdir/$pkgbase/"
-  ./install-gtex.sh dir:$pkgdir/usr/share/texmf-dist || return 1
+  ./install-gtex.sh dir:$pkgdir/usr/share/texmf || return 1
 }

--- a/gregorio/PKGBUILD
+++ b/gregorio/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=gregorio
 pkgname=$pkgbase
 pkgver=4.1.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Command-line tool to typeset Gregorian chant"
 url=http://gregorio-project.github.io
 arch=("i686" "x86_64")


### PR DESCRIPTION
Arch released the TL 2016 packages a few days ago. Arch's packages have gregorio 4.1.1 ('Gregorio 4.1.1 (kpathsea version 6.2.2).'), so these modifications install 4.1.4 over 4.1.1.

I tested this on a relatively large project I have, and everything worked. As far as I can tell, Gregorio's TeX files get installed in /usr/share/texmf (Arch's version of texmf-local) and the binary is in /usr/local/bin to avoid overwriting the TL one in /usr/bin. Does messing with the prefices for the install scripts (ie the changes I made) have any other effects?
