### PR TITLE
Update to v4.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ These files are released to the public domain. See the [Gregorio project](https:
 
 ##Changelog
 
+###2016-09-25
+
+####Changed
+- PKGBUILD for `gregorio` upgraded to v4.2.0.
+
 ###2016-08-09
 
 ####Changed

--- a/gregorio/PKGBUILD
+++ b/gregorio/PKGBUILD
@@ -3,8 +3,8 @@
 # Contributor: David Gippner davidgippner at googlemail dot com
 pkgbase=gregorio
 pkgname=$pkgbase
-pkgver=4.1.4
-pkgrel=2
+pkgver=4.2.0
+pkgrel=1
 pkgdesc="Command-line tool to typeset Gregorian chant"
 url=http://gregorio-project.github.io
 arch=("i686" "x86_64")
@@ -14,7 +14,7 @@ conflicts=("gregorio-svn" "gregorio-git" "gregoriotex")
 provides=("gregorio")
 install=gregorio.install
 source=("https://github.com/gregorio-project/gregorio/releases/download/v$pkgver/gregorio-$pkgver.tar.bz2")
-sha256sums=("971093bfe18becbeb8b019abd554503a75cb550f9a1501af40621904424aa35c")
+sha256sums=("64eddccc3ba6faf500ccbbab78fa7537dbd1a73999631e906c6b51ae1255c838")
 
 
 prepare() {


### PR DESCRIPTION
#10 did the work of making sure this version doesn't try to overwrite the main repository's TeX Live.
