### PR TITLE
Link docs to /usr/share/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ These files are released to the public domain. See the [Gregorio project](https:
 
 ## Changelog
 
+### 2022-12-18
+
+#### Changed
+- PKGBUILD for `gregorio` changed to link docs to `/usr/share/docs/gregorio`.
+- PKGBUILD for `gregorio-git` changed to specify `python2` in `makedepends`.
+
 ### 2021-03-14
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Problems with these packaging files can be left on the AUR ([gregorio](https://a
 ## Authors
 
 ### Current
-- Br Anthony VanBerkum
 - Br Elijah Schwab
 
 ### Past
+- Br Anthony VanBerkum
 - David Gippner
 - Laércio de Sousa
 

--- a/gregorio-git/PKGBUILD
+++ b/gregorio-git/PKGBUILD
@@ -2,13 +2,13 @@
 # Contributor: Br. Elijah Schwab (github - eschwab)
 pkgbase=gregorio-git
 pkgname=$pkgbase
-pkgver=5.2.0.r4342.8d81faff
+pkgver=6.0.0.r4528.c400a14e
 pkgrel=1
 pkgdesc="Command-line tool to typeset Gregorian chant"
 url=http://gregorio-project.github.io
 arch=("i686" "x86_64")
 license=("GPL")
-makedepends=("git" "python" "fontforge")
+makedepends=("git" "python2" "fontforge")
 depends=("texlive-core" "texlive-fontsextra" "texlive-bin" "texlive-formatsextra" "texlive-latexextra")
 conflicts=("gregorio-svn" "gregorio" "gregoriotex")
 provides=("gregorio")

--- a/gregorio/PKGBUILD
+++ b/gregorio/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=gregorio
 pkgname=$pkgbase
 pkgver=6.0.0
-pkgrel=1
+pkgrel=2
 _pkgver_underscores=$(echo $pkgver | sed -e 's/\./_/g')
 pkgdesc="Command-line tool to typeset Gregorian chant"
 url=http://gregorio-project.github.io
@@ -41,6 +41,10 @@ package() {
   msg "Installing TeX files..."
   cd "$srcdir/$pkgbase/"
   ./install-gtex.sh dir:$pkgdir/usr/share/texmf || return 1
+  msg "Linking docs to /usr/share/doc..."
+  mkdir -p $pkgdir/usr/share/doc/
+  cd $pkgdir/usr/share/doc
+  ln -s ../texmf/doc/luatex/gregoriotex gregorio
   msg "Installing fonts..."
   cd "$srcdir/"
   texlua install_supp_fonts.lua $pkgdir/usr/share/texmf || return 1


### PR DESCRIPTION
User `lquidfire` on the [AUR page](https://aur.archlinux.org/packages/gregorio#comment-893363) requested that we link the docs to `/usr/share/docs`. As far as I can tell, the Arch packages for texlive don't include docs by default, and the default docs location is `/usr/share/docs`, so this seems fine to me. Thoughts?